### PR TITLE
Add support for path or reference arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,13 +260,13 @@ function* syncUserSaga() {
 
 ### Database
 
-#### `*database.read(path)`
+#### `*database.read(pathOrRef)`
 
-Returns the data at this path in firebase's database.
+Returns the data at this path or reference in firebase's database.
 
 ##### Arguments
 
-- `path`: a string
+- `pathOrRef`: a string or [Firebase Database Reference](https://firebase.google.com/docs/reference/js/firebase.database.Reference)
 
 ##### Output
 
@@ -281,13 +281,13 @@ function* getTodo() {
 }
 ```
 
-#### `*database.create(path, data)`
+#### `*database.create(pathOrRef, data)`
 
 Create a new path in the database and stores the data there.
 
 ##### Arguments
 
-- `path`: a string
+- `pathOrRef`: a string or [Firebase Database Reference](https://firebase.google.com/docs/reference/js/firebase.database.Reference)
 - `data`: any value (number, string, object, etc)
 
 ##### Output
@@ -306,13 +306,13 @@ function* addTodo() {
 }
 ```
 
-#### `*database.update(path, data)`
+#### `*database.update(pathOrRef, data)`
 
-Replace the value store at `path` in the database with `data`.
+Replace the value store at `path` or reference in the database with `data`.
 
 ##### Arguments
 
-- `path`: a string
+- `pathOrRef`: a string or [Firebase Database Reference](https://firebase.google.com/docs/reference/js/firebase.database.Reference)
 - `data`: any value (number, string, object, etc)
 
 ##### Output
@@ -330,13 +330,13 @@ function* updateTodo() {
 }
 ```
 
-#### `*database.patch(path, data)`
+#### `*database.patch(pathOrRef, data)`
 
-Patches the value store at `path` in the database with `data`. Like `database.update` but doesn't remove unmentionned keys.
+Patches the value store at `path` or reference in the database with `data`. Like `database.update` but doesn't remove unmentionned keys.
 
 ##### Arguments
 
-- `path`: a string
+- `pathOrRef`: a string or [Firebase Database Reference](https://firebase.google.com/docs/reference/js/firebase.database.Reference)
 - `data`: any value (number, string, object, etc)
 
 ##### Output
@@ -354,13 +354,13 @@ function* updateTodo() {
 }
 ```
 
-#### `*database.delete(path)`
+#### `*database.delete(pathOrRef)`
 
-Removes the value at the specified `path` in the database.
+Removes the value at the specified `path` or reference in the database.
 
 ##### Arguments
 
-- `path`: a string
+- `pathOrRef`: a string or [Firebase Database Reference](https://firebase.google.com/docs/reference/js/firebase.database.Reference)
 
 ##### Output
 
@@ -374,13 +374,13 @@ function* deleteTodo() {
 }
 ```
 
-#### `database.channel(path, event)`
+#### `database.channel(pathOrRef, event)`
 
-Returns a redux-saga [Channel](https://redux-saga.github.io/redux-saga/docs/advanced/Channels.html) which emits every change at the specified path in the database.
+Returns a redux-saga [Channel](https://redux-saga.github.io/redux-saga/docs/advanced/Channels.html) which emits every change at the specified path or reference in the database.
 
 ##### Arguments
 
-- `path`: a string
+- `pathOrRef`: a string or [Firebase Database Reference](https://firebase.google.com/docs/reference/js/firebase.database.Reference)
 - `event` (default: `value`): a string describing the type of event to listen for. Options includes: `value`, `child_added`, `child_removed`, `child_changed` and `child_moved`. See [Reference.on](https://firebase.google.com/docs/reference/js/firebase.database.Reference#on) documentation for more information.
 
 ##### Output
@@ -496,13 +496,13 @@ function* refreshToken() {
 
 ### Storage
 
-#### `storage.uploadFile(path, file, metadata)`
+#### `storage.uploadFile(pathOrRef, file, metadata)`
 
 Uploads a file to cloud storage.
 
 ##### Arguments
 
-- `path`: a string representing the path of the file in the bucket.
+- `pathOrRef`: a string or [Firebase Storage Reference](https://firebase.google.com/docs/reference/js/firebase.storage.Reference) representing the path of the file in the bucket.
 - `file`: a [`Blob`](https://developer.mozilla.org/en/docs/Web/API/Blob), a [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) or an [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) to upload at the specified `path`.
 - `metadata` (optional): an [UploadMetadata](https://firebase.google.com/docs/reference/js/firebase.storage.UploadMetadata) object.
 
@@ -527,13 +527,13 @@ function* uploadFile(action) {
 }
 ```
 
-#### `storage.uploadString(path, string, format, metadata)`
+#### `storage.uploadString(pathOrRef, string, format, metadata)`
 
 Use this to upload a raw, `base64`, `base64url`, or `data_url` encoded string to Cloud Storage.
 
 ##### Arguments
 
-- `path`: a string representing the path of the file in the bucket.
+- `pathOrRef`: a string or [Firebase Storage Reference](https://firebase.google.com/docs/reference/js/firebase.storage.Reference) representing the path of the file in the bucket.
 - `string`: a string to upload.
 - `format` (optional): a string. Available options are: `base64`, `base64url`, or `data_url`.
 - `metadata` (optional): an [UploadMetadata](https://firebase.google.com/docs/reference/js/firebase.storage.UploadMetadata) object.
@@ -559,13 +559,13 @@ function* uploadString(action) {
 }
 ```
 
-#### `*storage.getDownloadURL(path)`
+#### `*storage.getDownloadURL(pathOrRef)`
 
 Returns a download url for the file at the specified path.
 
 ##### Arguments
 
-- `path`: a string representing the path of the file in the bucket.
+- `pathOrRef`: a string or [Firebase Storage Reference](https://firebase.google.com/docs/reference/js/firebase.storage.Reference) representing the path of the file in the bucket.
 
 ##### Output
 
@@ -581,11 +581,11 @@ function* downloadFile(action) {
 }
 ```
 
-#### `*storage.getFileMetadata(path)`
+#### `*storage.getFileMetadata(pathOrRef)`
 
 ##### Arguments
 
-- `path`: a string representing the path of the file in the bucket.
+- `pathOrRef`: a string or [Firebase Storage Reference](https://firebase.google.com/docs/reference/js/firebase.storage.Reference) representing the path of the file in the bucket.
 
 ##### Output
 
@@ -600,13 +600,13 @@ function* metadata(action) {
 }
 ```
 
-#### `*storage.updateFileMetadata(path, newMetadata)`
+#### `*storage.updateFileMetadata(pathOrRef, newMetadata)`
 
 Updates the metadata for a file.
 
 ##### Arguments
 
-- `path`: a string representing the path of the file in the bucket.
+- `pathOrRef`: a string or [Firebase Storage Reference](https://firebase.google.com/docs/reference/js/firebase.storage.Reference) representing the path of the file in the bucket.
 - `newMetadata`: an object with keys from the [SettableMetadata](https://firebase.google.com/docs/reference/js/firebase.storage.SettableMetadata) interface.
 
 ##### Output
@@ -624,13 +624,13 @@ function* setToPng(action) {
 }
 ```
 
-#### `*storage.deleteFile(path)`
+#### `*storage.deleteFile(pathOrRef)`
 
 Deletes a file.
 
 ##### Arguments
 
-- `path`: a string representing the path of the file in the bucket.
+- `pathOrRef`: a string or [Firebase Storage Reference](https://firebase.google.com/docs/reference/js/firebase.storage.Reference) representing the path of the file in the bucket.
 
 ##### Output
 

--- a/src/database.js
+++ b/src/database.js
@@ -1,37 +1,37 @@
 import { eventChannel } from 'redux-saga'
 import { call } from 'redux-saga/effects'
 
-function * read (path) {
-  const ref = this.app.database().ref(path)
+function * read (pathOrRef) {
+  const ref = this._getRef(pathOrRef, 'database')
   const result = yield call([ref, ref.once], 'value')
 
   return result.val()
 }
 
-function * create (path, data) {
-  const ref = this.app.database().ref(path)
+function * create (pathOrRef, data) {
+  const ref = this._getRef(pathOrRef, 'database')
   const result = yield call([ref, ref.push], data)
 
   return result.key
 }
 
-function * update (path, data) {
-  const ref = this.app.database().ref(path)
+function * update (pathOrRef, data) {
+  const ref = this._getRef(pathOrRef, 'database')
   yield call([ref, ref.set], data)
 }
 
-function * patch (path, data) {
-  const ref = this.app.database().ref(path)
+function * patch (pathOrRef, data) {
+  const ref = this._getRef(pathOrRef, 'database')
   yield call([ref, ref.update], data)
 }
 
-function * _delete (path) {
-  const ref = this.app.database().ref(path)
+function * _delete (pathOrRef) {
+  const ref = this._getRef(pathOrRef, 'database')
   yield call([ref, ref.remove])
 }
 
-function channel (path, event = 'value') {
-  const ref = this.app.database().ref(path)
+function channel (pathOrRef, event = 'value') {
+  const ref = this._getRef(pathOrRef, 'database')
 
   const channel = eventChannel(emit => {
     const callback = ref.on(

--- a/src/database.test.js
+++ b/src/database.test.js
@@ -3,7 +3,7 @@ import { call } from 'redux-saga/effects'
 import dbModule from './database'
 
 describe('database', () => {
-  let ref, database, context, subs
+  let ref, context, subs
 
   beforeEach(() => {
     subs = []
@@ -18,13 +18,8 @@ describe('database', () => {
       set: jest.fn(),
       update: jest.fn()
     }
-    database = {
-      ref: jest.fn(() => ref)
-    }
     context = {
-      app: {
-        database: jest.fn(() => database)
-      }
+      _getRef: jest.fn(() => ref)
     }
   })
 
@@ -42,13 +37,10 @@ describe('database', () => {
       const iterator = dbModule.read.call(context, path)
 
       expect(iterator.next().value)
-      .toEqual(call([ref, ref.once], 'value'))
+        .toEqual(call([ref, ref.once], 'value'))
 
-      expect(context.app.database.mock.calls.length).toBe(1)
-      expect(context.app.database.mock.calls[0]).toEqual([])
-
-      expect(database.ref.mock.calls.length).toBe(1)
-      expect(database.ref.mock.calls[0]).toEqual([path])
+      expect(context._getRef.mock.calls.length).toBe(1)
+      expect(context._getRef.mock.calls[0]).toEqual([path, 'database'])
 
       expect(iterator.next(result)).toEqual({
         done: true,
@@ -70,13 +62,10 @@ describe('database', () => {
       const iterator = dbModule.create.call(context, path, data)
 
       expect(iterator.next().value)
-      .toEqual(call([ref, ref.push], data))
+        .toEqual(call([ref, ref.push], data))
 
-      expect(context.app.database.mock.calls.length).toBe(1)
-      expect(context.app.database.mock.calls[0]).toEqual([])
-
-      expect(database.ref.mock.calls.length).toBe(1)
-      expect(database.ref.mock.calls[0]).toEqual([path])
+      expect(context._getRef.mock.calls.length).toBe(1)
+      expect(context._getRef.mock.calls[0]).toEqual([path, 'database'])
 
       expect(iterator.next(result)).toEqual({
         done: true,
@@ -92,13 +81,10 @@ describe('database', () => {
       const iterator = dbModule.update.call(context, path, data)
 
       expect(iterator.next().value)
-      .toEqual(call([ref, ref.set], data))
+        .toEqual(call([ref, ref.set], data))
 
-      expect(context.app.database.mock.calls.length).toBe(1)
-      expect(context.app.database.mock.calls[0]).toEqual([])
-
-      expect(database.ref.mock.calls.length).toBe(1)
-      expect(database.ref.mock.calls[0]).toEqual([path])
+      expect(context._getRef.mock.calls.length).toBe(1)
+      expect(context._getRef.mock.calls[0]).toEqual([path, 'database'])
 
       expect(iterator.next()).toEqual({
         done: true,
@@ -114,13 +100,10 @@ describe('database', () => {
       const iterator = dbModule.patch.call(context, path, data)
 
       expect(iterator.next().value)
-      .toEqual(call([ref, ref.update], data))
+        .toEqual(call([ref, ref.update], data))
 
-      expect(context.app.database.mock.calls.length).toBe(1)
-      expect(context.app.database.mock.calls[0]).toEqual([])
-
-      expect(database.ref.mock.calls.length).toBe(1)
-      expect(database.ref.mock.calls[0]).toEqual([path])
+      expect(context._getRef.mock.calls.length).toBe(1)
+      expect(context._getRef.mock.calls[0]).toEqual([path, 'database'])
 
       expect(iterator.next()).toEqual({
         done: true,
@@ -135,13 +118,10 @@ describe('database', () => {
       const iterator = dbModule.delete.call(context, path)
 
       expect(iterator.next().value)
-      .toEqual(call([ref, ref.remove]))
+        .toEqual(call([ref, ref.remove]))
 
-      expect(context.app.database.mock.calls.length).toBe(1)
-      expect(context.app.database.mock.calls[0]).toEqual([])
-
-      expect(database.ref.mock.calls.length).toBe(1)
-      expect(database.ref.mock.calls[0]).toEqual([path])
+      expect(context._getRef.mock.calls.length).toBe(1)
+      expect(context._getRef.mock.calls[0]).toEqual([path, 'database'])
 
       expect(iterator.next()).toEqual({
         done: true,
@@ -156,11 +136,8 @@ describe('database', () => {
       const event = 'okqdkj'
       dbModule.channel.call(context, path, event)
 
-      expect(context.app.database.mock.calls.length).toBe(1)
-      expect(context.app.database.mock.calls[0]).toEqual([])
-
-      expect(database.ref.mock.calls.length).toBe(1)
-      expect(database.ref.mock.calls[0]).toEqual([path])
+      expect(context._getRef.mock.calls.length).toBe(1)
+      expect(context._getRef.mock.calls[0]).toEqual([path, 'database'])
 
       expect(ref.on.mock.calls.length).toBe(1)
       expect(ref.on.mock.calls[0][0]).toBe(event)

--- a/src/index.js
+++ b/src/index.js
@@ -20,12 +20,12 @@ class ReduxSagaFirebase {
 
     // Database methods
     this.database = {
-      read: database.read.bind(this),
-      create: database.create.bind(this),
-      update: database.update.bind(this),
-      patch: database.patch.bind(this),
-      delete: database.delete.bind(this),
-      channel: database.channel.bind(this)
+      read: database.read,
+      create: database.create,
+      update: database.update,
+      patch: database.patch,
+      delete: database.delete,
+      channel: database.channel
     }
 
     // Functions methods
@@ -41,12 +41,12 @@ class ReduxSagaFirebase {
 
     // Storage methods
     this.storage = {
-      uploadFile: storage.uploadFile.bind(this),
-      uploadString: storage.uploadString.bind(this),
-      getDownloadURL: storage.getDownloadURL.bind(this),
-      getFileMetadata: storage.getFileMetadata.bind(this),
-      updateFileMetadata: storage.updateFileMetadata.bind(this),
-      deleteFile: storage.deleteFile.bind(this)
+      uploadFile: storage.uploadFile,
+      uploadString: storage.uploadString,
+      getDownloadURL: storage.getDownloadURL,
+      getFileMetadata: storage.getFileMetadata,
+      updateFileMetadata: storage.updateFileMetadata,
+      deleteFile: storage.deleteFile
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,12 +20,12 @@ class ReduxSagaFirebase {
 
     // Database methods
     this.database = {
-      read: database.read,
-      create: database.create,
-      update: database.update,
-      patch: database.patch,
-      delete: database.delete,
-      channel: database.channel
+      read: database.read.bind(this),
+      create: database.create.bind(this),
+      update: database.update.bind(this),
+      patch: database.patch.bind(this),
+      delete: database.delete.bind(this),
+      channel: database.channel.bind(this)
     }
 
     // Functions methods
@@ -41,12 +41,12 @@ class ReduxSagaFirebase {
 
     // Storage methods
     this.storage = {
-      uploadFile: storage.uploadFile,
-      uploadString: storage.uploadString,
-      getDownloadURL: storage.getDownloadURL,
-      getFileMetadata: storage.getFileMetadata,
-      updateFileMetadata: storage.updateFileMetadata,
-      deleteFile: storage.deleteFile
+      uploadFile: storage.uploadFile.bind(this),
+      uploadString: storage.uploadString.bind(this),
+      getDownloadURL: storage.getDownloadURL.bind(this),
+      getFileMetadata: storage.getFileMetadata.bind(this),
+      updateFileMetadata: storage.updateFileMetadata.bind(this),
+      deleteFile: storage.deleteFile.bind(this)
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,12 @@ class ReduxSagaFirebase {
 
     return projectId
   }
+
+  _getRef (pathOrRef, service) {
+    return (typeof pathOrRef === 'string')
+      ? this.app[service]().ref(pathOrRef)
+      : pathOrRef
+  }
 }
 
 export default ReduxSagaFirebase

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -89,4 +89,72 @@ describe('ReduxSagaFirebase', () => {
       expect(rsf.projectId()).toBe(projectId)
     })
   })
+
+  describe('_getRef(pathOrRef, service)', () => {
+    let databaseRef, storageRef, database, storage, app, rsf
+
+    beforeEach(() => {
+      databaseRef = {
+        key: 'key'
+      }
+      storageRef = {
+        bucket: 'bucket'
+      }
+      database = {
+        ref: jest.fn(() => databaseRef)
+      }
+      storage = {
+        ref: jest.fn(() => storageRef)
+      }
+      app = {
+        database: jest.fn(() => database),
+        storage: jest.fn(() => storage)
+      }
+      rsf = new ReduxSagaFirebase(app)
+    })
+
+    it('returns a database ref from path string', () => {
+      const path = 'path'
+      const ref = rsf._getRef(path, 'database')
+
+      expect(app.database.mock.calls.length).toBe(1)
+      expect(app.database.mock.calls[0]).toEqual([])
+
+      expect(database.ref.mock.calls.length).toBe(1)
+      expect(database.ref.mock.calls[0]).toEqual([path])
+
+      expect(ref).toEqual(databaseRef)
+    })
+
+    it('returns the database ref that was passed to it', () => {
+      const ref = rsf._getRef(databaseRef)
+
+      expect(app.database.mock.calls.length).toBe(0)
+      expect(database.ref.mock.calls.length).toBe(0)
+
+      expect(ref).toEqual(databaseRef)
+    })
+
+    it('returns a storage ref from path string', () => {
+      const path = 'path'
+      const ref = rsf._getRef(path, 'storage')
+
+      expect(app.storage.mock.calls.length).toBe(1)
+      expect(app.storage.mock.calls[0]).toEqual([])
+
+      expect(storage.ref.mock.calls.length).toBe(1)
+      expect(storage.ref.mock.calls[0]).toEqual([path])
+
+      expect(ref).toEqual(storageRef)
+    })
+
+    it('returns the storage ref that was passed to it', () => {
+      const ref = rsf._getRef(storageRef)
+
+      expect(app.storage.mock.calls.length).toBe(0)
+      expect(storage.ref.mock.calls.length).toBe(0)
+
+      expect(ref).toEqual(storageRef)
+    })
+  })
 })

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,42 +1,42 @@
 import { call } from 'redux-saga/effects'
 
-function uploadFile (path, file, metadata) {
-  const ref = this.app.storage().ref(path)
+function uploadFile (pathOrRef, file, metadata) {
+  const ref = this._getRef(pathOrRef, 'storage')
   const task = ref.put(file, metadata)
 
   return task
 }
 
-function uploadString (path, string, format, metadata) {
-  const ref = this.app.storage().ref(path)
+function uploadString (pathOrRef, string, format, metadata) {
+  const ref = this._getRef(pathOrRef, 'storage')
   const task = ref.putString(string, format, metadata)
 
   return task
 }
 
-function * getDownloadURL (path) {
-  const ref = this.app.storage().ref(path)
+function * getDownloadURL (pathOrRef) {
+  const ref = this._getRef(pathOrRef, 'storage')
   const url = yield call([ref, ref.getDownloadURL])
 
   return url
 }
 
-function * getFileMetadata (path) {
-  const ref = this.app.storage().ref(path)
+function * getFileMetadata (pathOrRef) {
+  const ref = this._getRef(pathOrRef, 'storage')
   const metadata = yield call([ref, ref.getMetadata])
 
   return metadata
 }
 
-function * updateFileMetadata (path, newMetadata) {
-  const ref = this.app.storage().ref(path)
+function * updateFileMetadata (pathOrRef, newMetadata) {
+  const ref = this._getRef(pathOrRef, 'storage')
   const metadata = yield call([ref, ref.updateMetadata], newMetadata)
 
   return metadata
 }
 
-function * deleteFile (path) {
-  const ref = this.app.storage().ref(path)
+function * deleteFile (pathOrRef) {
+  const ref = this._getRef(pathOrRef, 'storage')
   yield call([ref, ref.delete])
 }
 

--- a/src/storage.test.js
+++ b/src/storage.test.js
@@ -3,7 +3,7 @@ import { call } from 'redux-saga/effects'
 import storageModule from './storage'
 
 describe('storage', () => {
-  let ref, storage, task, context
+  let ref, task, context
 
   task = 'qlsdmlqmd'
 
@@ -16,13 +16,8 @@ describe('storage', () => {
       putString: jest.fn(() => task),
       updateMetadata: jest.fn()
     }
-    storage = {
-      ref: jest.fn(() => ref)
-    }
     context = {
-      app: {
-        storage: jest.fn(() => storage)
-      }
+      _getRef: jest.fn(() => ref)
     }
   })
 
@@ -38,11 +33,8 @@ describe('storage', () => {
 
       const result = storageModule.uploadFile.call(context, path, file, metadata)
 
-      expect(context.app.storage.mock.calls.length).toBe(1)
-      expect(context.app.storage.mock.calls[0]).toEqual([])
-
-      expect(storage.ref.mock.calls.length).toBe(1)
-      expect(storage.ref.mock.calls[0]).toEqual([path])
+      expect(context._getRef.mock.calls.length).toBe(1)
+      expect(context._getRef.mock.calls[0]).toEqual([path, 'storage'])
 
       expect(ref.put.mock.calls.length).toBe(1)
       expect(ref.put.mock.calls[0]).toEqual([file, metadata])
@@ -60,11 +52,8 @@ describe('storage', () => {
 
       const result = storageModule.uploadString.call(context, path, string, format, metadata)
 
-      expect(context.app.storage.mock.calls.length).toBe(1)
-      expect(context.app.storage.mock.calls[0]).toEqual([])
-
-      expect(storage.ref.mock.calls.length).toBe(1)
-      expect(storage.ref.mock.calls[0]).toEqual([path])
+      expect(context._getRef.mock.calls.length).toBe(1)
+      expect(context._getRef.mock.calls[0]).toEqual([path, 'storage'])
 
       expect(ref.putString.mock.calls.length).toBe(1)
       expect(ref.putString.mock.calls[0]).toEqual([string, format, metadata])
@@ -80,13 +69,10 @@ describe('storage', () => {
       const iterator = storageModule.getDownloadURL.call(context, path)
 
       expect(iterator.next().value)
-      .toEqual(call([ref, ref.getDownloadURL]))
+        .toEqual(call([ref, ref.getDownloadURL]))
 
-      expect(context.app.storage.mock.calls.length).toBe(1)
-      expect(context.app.storage.mock.calls[0]).toEqual([])
-
-      expect(storage.ref.mock.calls.length).toBe(1)
-      expect(storage.ref.mock.calls[0]).toEqual([path])
+      expect(context._getRef.mock.calls.length).toBe(1)
+      expect(context._getRef.mock.calls[0]).toEqual([path, 'storage'])
 
       expect(iterator.next(url)).toEqual({
         done: true,
@@ -102,13 +88,10 @@ describe('storage', () => {
       const iterator = storageModule.getFileMetadata.call(context, path)
 
       expect(iterator.next().value)
-      .toEqual(call([ref, ref.getMetadata]))
+        .toEqual(call([ref, ref.getMetadata]))
 
-      expect(context.app.storage.mock.calls.length).toBe(1)
-      expect(context.app.storage.mock.calls[0]).toEqual([])
-
-      expect(storage.ref.mock.calls.length).toBe(1)
-      expect(storage.ref.mock.calls[0]).toEqual([path])
+      expect(context._getRef.mock.calls.length).toBe(1)
+      expect(context._getRef.mock.calls[0]).toEqual([path, 'storage'])
 
       expect(iterator.next(metadata)).toEqual({
         done: true,
@@ -125,13 +108,10 @@ describe('storage', () => {
       const iterator = storageModule.updateFileMetadata.call(context, path, newMetadata)
 
       expect(iterator.next().value)
-      .toEqual(call([ref, ref.updateMetadata], newMetadata))
+        .toEqual(call([ref, ref.updateMetadata], newMetadata))
 
-      expect(context.app.storage.mock.calls.length).toBe(1)
-      expect(context.app.storage.mock.calls[0]).toEqual([])
-
-      expect(storage.ref.mock.calls.length).toBe(1)
-      expect(storage.ref.mock.calls[0]).toEqual([path])
+      expect(context._getRef.mock.calls.length).toBe(1)
+      expect(context._getRef.mock.calls[0]).toEqual([path, 'storage'])
 
       expect(iterator.next(metadata)).toEqual({
         done: true,
@@ -146,13 +126,10 @@ describe('storage', () => {
       const iterator = storageModule.deleteFile.call(context, path)
 
       expect(iterator.next().value)
-      .toEqual(call([ref, ref.delete]))
+        .toEqual(call([ref, ref.delete]))
 
-      expect(context.app.storage.mock.calls.length).toBe(1)
-      expect(context.app.storage.mock.calls[0]).toEqual([])
-
-      expect(storage.ref.mock.calls.length).toBe(1)
-      expect(storage.ref.mock.calls[0]).toEqual([path])
+      expect(context._getRef.mock.calls.length).toBe(1)
+      expect(context._getRef.mock.calls[0]).toEqual([path, 'storage'])
 
       expect(iterator.next()).toEqual({
         done: true,


### PR DESCRIPTION
Implements #34.

Firebase services that use `path` as an argument (Database, Storage) can now accept either a path string or either a [Firebase Database Reference](https://firebase.google.com/docs/reference/js/firebase.database.Reference) (or [Firebase Database Query](https://firebase.google.com/docs/reference/js/firebase.database.Query)), or a [Firebase Storage Reference](https://firebase.google.com/docs/reference/js/firebase.storage.Reference).

This provides the developer with access to the ref, specifically its properties and methods, before calling the RSF method. For example, the developer can get the parent reference, or a database key or storage bucket, or can construct a database Query to support [sorting and filtering data](https://firebase.google.com/docs/database/web/lists-of-data#sorting_and_filtering_data).