### PR TITLE
fix regex bug with the project id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ class ReduxSagaFirebase {
   projectId () {
     if (this._projectId) return this._projectId
 
-    const regex = /^([a-z0-9-]+?)(?:-[a-z0-9]{5})?\.firebaseapp\.com$/
+    const regex = /^([a-z0-9-]+?(-[a-z0-9]{5})*)?\.firebaseapp\.com$/
     const projectId = this.app.options.authDomain.match(regex)[1]
 
     this._projectId = projectId

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -100,10 +100,10 @@ describe('ReduxSagaFirebase', () => {
     })
 
     it('infers a project id from the firebase app (complex)', () => {
-      const projectId = 'jskdqdlqd'
+      const projectId = 'jskdqdlqd-a1b2c'
       const app = {
         options: {
-          authDomain: `${projectId}-a1b2c.firebaseapp.com`
+          authDomain: `${projectId}.firebaseapp.com`
         }
       }
       const rsf = new ReduxSagaFirebase(app)


### PR DESCRIPTION
There is a bug when you try to use the firebase functions. The Project ID is not returned as expected on the function projectId(). The problem is caused by the regex. I also changed the tests.

Example Configuration:
{
    apiKey: 'REzaSRBuGdtWopptyQnmvjQG45pB08IDC3lZpOE',
    authDomain: 'adadfs-tt02b.firebaseapp.com',
    databaseURL: 'https://adadfs-tt02b.firebaseio.com',
    projectId: 'adadfs-tt02b',
    storageBucket: 'adadfs-tt02b.appspot.com',
    messagingSenderId: '511743982260'
}