### PR TITLE
Refactor login. Fixes #103.

### DIFF
--- a/example/src/redux/actions/login.js
+++ b/example/src/redux/actions/login.js
@@ -8,17 +8,16 @@ export const types = {
     REQUEST: 'LOGOUT.REQUEST',
     SUCCESS: 'LOGOUT.SUCCESS',
     FAILURE: 'LOGOUT.FAILURE'
-  },
-  SYNC_USER: 'SYNC_USER'
+  }
 }
 
 export const login = () => ({
   type: types.LOGIN.REQUEST
 })
 
-export const loginSuccess = credential => ({
+export const loginSuccess = user => ({
   type: types.LOGIN.SUCCESS,
-  credential
+  user
 })
 
 export const loginFailure = error => ({
@@ -37,9 +36,4 @@ export const logoutSuccess = () => ({
 export const logoutFailure = error => ({
   type: types.LOGOUT.FAILURE,
   error
-})
-
-export const syncUser = user => ({
-  type: types.SYNC_USER,
-  user
 })

--- a/example/src/redux/reducer/login.js
+++ b/example/src/redux/reducer/login.js
@@ -18,7 +18,8 @@ export default function loginReducer (state = initialState, action = {}) {
       return {
         ...state,
         loading: false,
-        loggedIn: true
+        loggedIn: true,
+        user: action.user
       }
     case types.LOGIN.FAILURE:
       return {
@@ -26,21 +27,11 @@ export default function loginReducer (state = initialState, action = {}) {
         loading: false
       }
     case types.LOGOUT.SUCCESS:
-      return {
-        ...state,
-        loading: false,
-        loggedIn: false
-      }
+      return initialState
     case types.LOGOUT.FAILURE:
       return {
         ...state,
         loading: false
-      }
-    case types.SYNC_USER:
-      return {
-        ...state,
-        loggedIn: action.user != null,
-        user: action.user
       }
     default:
       return state


### PR DESCRIPTION
This PR slightly changes how login and logout work on the example app.

Before this PR, the `loggedIn` and `loggedOut` properties were set independently from the `user`, meaning that it was possible to get into an inconsistent state, as highlighted in #103.

In this PR,

* The `loginSuccess` and `logoutSuccess` actions are triggered only when an event is received on the `rsf.auth.channel`. These events are received when a user logs in or logs out successfully (see [onAuthChanged](https://firebase.google.com/docs/reference/js/firebase.auth.Auth#onAuthStateChanged)).
* The `syncUser` action is removed, as every case is now covered by `loginSuccess` and `logoutSuccess`