### PR TITLE
Better typing for PathOrRef.Collection

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,9 @@ declare enum FirestoreType {
 
 declare namespace PathOrRef {
   type Base<R> = string | R
-  type Collection = Base<firebase.firestore.CollectionReference>
+  type Collection = Base<
+    firebase.firestore.CollectionReference | firebase.firestore.Query
+  >
   type Database = Base<firebase.database.Reference>
   type Document = Base<firebase.firestore.DocumentReference>
   type Storage = Base<firebase.storage.Reference>

--- a/src/firestore.test.js
+++ b/src/firestore.test.js
@@ -4,7 +4,7 @@ import firestoreModule, { getCollectionRef, getDocumentRef } from './firestore'
 import { syncChannel } from './utils'
 
 describe('firestore', () => {
-  let app, collection, context, document, firestore, unsubscribe
+  let app, collection, context, document, firestore, query, unsubscribe
 
   beforeEach(() => {
     unsubscribe = jest.fn()
@@ -20,6 +20,13 @@ describe('firestore', () => {
       doc: jest.fn(() => document),
       get: jest.fn(),
       onSnapshot: jest.fn(() => unsubscribe),
+    }
+    query = {
+      get: jest.fn(),
+      limit: jest.fn(),
+      onSnapshot: jest.fn(() => unsubscribe),
+      orderBy: jest.fn(),
+      where: jest.fn(),
     }
     firestore = {
       collection: jest.fn(() => collection),
@@ -201,6 +208,27 @@ describe('firestore', () => {
       const iterator = firestoreModule.getCollection.call(context, collection)
 
       expect(iterator.next().value).toEqual(call([collection, collection.get]))
+
+      expect(app.firestore.mock.calls.length).toBe(0)
+      expect(firestore.collection.mock.calls.length).toBe(0)
+
+      expect(iterator.next(response)).toEqual({
+        done: true,
+        value: response,
+      })
+    })
+
+    it('accepts a firebase.firestore.Query', () => {
+      const val = 'asd'
+      const result = {
+        data: jest.fn(() => val),
+        id: val,
+      }
+      const response = [result, result]
+
+      const iterator = firestoreModule.getCollection.call(context, query)
+
+      expect(iterator.next().value).toEqual(call([query, query.get]))
 
       expect(app.firestore.mock.calls.length).toBe(0)
       expect(firestore.collection.mock.calls.length).toBe(0)


### PR DESCRIPTION
According to [Document of firestore.getCollection](https://redux-saga-firebase.js.org/reference/dev/firestore/#getCollection), we can pass the arg typing [firebase.firestore.Query](https://firebase.google.com/docs/reference/js/firebase.firestore.Query).  
But in fact, the code like this get TS error.

## Code

```typescript
const data: firebase.firestore.QuerySnapshot = yield call(
  rsf.firestore.getCollection,
  firestore.collection("data").orderBy("sort")
);
```

## Error

```

{
	"resource": "saga.ts",
	"owner": "typescript",
	"code": "2345",
	"severity": 8,
	"message": "Argument of type '(collectionRef: Base<CollectionReference>) => IterableIterator<CallEffect | RootEffect | TakeEffect | ChannelTakeEffect<any> | PutEffect<any> | ChannelPutEffect<any> | AllEffect | ... 11 more ... | Effect[]>' is not assignable to parameter of type 'CallEffectNamedFn<{ [x: string]: Func1<Query>; }, string>'.\n  Type '(collectionRef: Base<CollectionReference>) => IterableIterator<CallEffect | RootEffect | TakeEffect | ChannelTakeEffect<any> | PutEffect<any> | ChannelPutEffect<any> | AllEffect | ... 11 more ... | Effect[]>' is missing the following properties from type '{ context: { [x: string]: Func1<Query>; }; fn: string; }': context, fn",
	"source": "ts",
	"startLineNumber": 11,
	"startColumn": 7,
	"endLineNumber": 11,
	"endColumn": 34
}
```